### PR TITLE
bugfix: change parameter mode to string

### DIFF
--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -120,7 +120,7 @@ class meteor::app (
       ensure => present,
       source => "puppet:///modules/meteor/http_upgrade.conf",
       mode   => "755",
-      owner  => "www-data"
+      # owner  => "www-data"
     }->
     nginx::resource::vhost { $app_vhost_name:
       proxy            => "http://${app_name}_proxy",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,7 +22,7 @@ class meteor::install (
   ### make sure it's owned by root and executable
   file { "/usr/share/install_meteor.sh":
     ensure => present,
-    mode   => 755,
+    mode   => "0755",
     owner  => "root",
     group  => "root"
   }->


### PR DESCRIPTION
The file mode specification must be a string, not 'Fixnum'